### PR TITLE
Remove print for debugging

### DIFF
--- a/osc.go
+++ b/osc.go
@@ -115,7 +115,6 @@ func (o *Osc) Sample() (output float64) {
 	case WaveSaw:
 		output = amp*Sawtooth(o.CurrentPhaseAngle) + o.DcOffset
 	case WaveSqr:
-		fmt.Println(o.CurrentPhaseAngle)
 		output = amp*Square(o.CurrentPhaseAngle) + o.DcOffset
 	}
 


### PR DESCRIPTION
Was producing tons of unnecessary console outputs before

```
-2.7767811468878
-2.7621957184519337
-2.7476102900160675
-2.7330248615802013
-2.718439433144335
-2.703854004708469
-2.6892685762726027
-2.6746831478367366
-2.6600977194008704
-2.645512290965004
-2.630926862529138
-2.616341434093272
-2.6017560056574056
-2.5871705772215394
-2.5725851487856732
-2.557999720349807
...
```